### PR TITLE
Merging updated MLIR grammar from mlir-vscode repo

### DIFF
--- a/grammars/mlir.json
+++ b/grammars/mlir.json
@@ -1,112 +1,590 @@
 {
-  "fileTypes":[
+  "fileTypes": [
     "mlir"
   ],
-  "repository":{
-    "attribute":{
-      "match":"\\W[\\w_][\\w\\d_.$]*\\s*=",
-      "name":"meta.attribute.mlir"
+  "repository": {
+    "attribute": {
+      "match": "\\W[\\w_][\\w\\d_.$]*\\s*=",
+      "name": "meta.attribute.mlir"
     },
-    "branch_target":{
-      "match":"\\^bb[\\w\\d_$\\.-]+",
-      "name":"entity.name.label.mlir"
+    "branch_target": {
+      "match": "\\^bb[\\w\\d_$\\.-]+",
+      "name": "entity.name.label.mlir"
     },
-    "comment":{
-      "match":"\/\/.*$",
-      "name":"comment.line.double-slash.mlir"
+    "comment": {
+      "match": "\/\/.*$",
+      "name": "comment.line.double-slash.mlir"
     },
-    "identifier":{
-      "match":"[\\%#@][\\w_][\\w\\d_.$]*",
-      "captures":{
-        "0":{
-          "name":"variable.mlir"
+    "identifier": {
+      "match": "[\\%#@][\\w_][\\w\\d_.$]*",
+      "captures": {
+        "0": {
+          "name": "variable.mlir"
         }
       },
-      "name":"meta.identifier.mlir"
+      "name": "meta.identifier.mlir"
     },
-    "integer":{
-      "match":"[\\Wx]([0-9]+)",
-      "captures":{
-        "1":{
-          "name":"constant.numeric.mlir"
+    "numbers": {
+      "match": "(?<=\\W|e|E)(-)?([0-9]+)(((x|-)[0-9]+)*|\\.[0-9]+)(?=\\W|e|E)",
+      "name": "constant.numeric.mlir"
+    },
+    "string": {
+      "end": "\"",
+      "begin": "\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.mlir"
         }
       },
-      "name":"meta.identifier.mlir"
-    },
-    "string":{
-      "end":"\"",
-      "begin":"\"",
-      "beginCaptures":{
-        "0":{
-          "name":"punctuation.definition.string.begin.mlir"
-        }
-      },
-      "patterns":[
+      "patterns": [
         {
-          "match":"\\\\[nt\"]",
-          "name":"constant.character.escape.mlir"
+          "match": "\\\\[nt\"]",
+          "name": "constant.character.escape.mlir"
         },
         {
-          "match":"\\\\.",
-          "name":"invalid.illegal.mlir"
+          "match": "\\\\.",
+          "name": "invalid.illegal.mlir"
         }
       ],
-      "endCaptures":{
-        "0":{
-          "name":"punctuation.definition.string.end.mlir"
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.mlir"
         }
       },
-      "name":"string.quoted.double.mlir"
+      "name": "string.quoted.double.mlir"
     },
-    "types":{
-      "match":"[\\Wx](index|i[1-9][0-9]*|f16|bf16|f32|f64|memref|tensor|vector)\\b",
-      "captures":{
-        "1":{
-          "name":"storage.type.mlir"
+    "types": {
+      "match": "\\b(index|i[1-9][0-9]*|f16|bf16|f32|f64|u8|ui32|si32|memref|tensor|vector)\\b",
+      "captures": {
+        "1": {
+          "name": "storage.type.mlir"
         }
       },
-      "name":"meta.types.simple.mlir"
+      "name": "meta.types.simple.mlir"
+    },
+    "memref-size": {
+      "match": "(?<=<)\\s*(((\\?|[1-9][0-9]*)\\s*x\\s*)*)(i[1-9][0-9]*|f16|bf16|f32|f64|u8|ui32|si32|!quant\\.uniform|vector|tensor|memref|!)\\b",
+      "captures":{
+        "0":{
+          "name": "storage.type.mlir.size"
+        },
+        "1":{
+          "name":"constant.numeric.size.mlir"
+        }
+      },
+      "name": "meta.type.mlir.size"
+    },
+    "affineOps": {
+      "match": "\\baffine\\.(for|apply|if|load|store|dma_start|dma_wait|min|max|parallel|prefetch)\\b",
+      "name": "entity.name.function.mlir.affineOps"
+    },
+    "affineOpsP": {
+      "match": "(?<=\\W)\"affine\\.(for|apply|if|load|store|dma_start|dma_wait|min|max|parallel|prefetch)\"(?=\\W)",
+      "name": "entity.name.function.mlir.affineOpsP"
+    },
+    "affineStructures": {
+      "match": "\\baffine_(map|set)\\b",
+      "name": "entity.name.function.mlir.affineStructures"
+    },
+    "llvmType": {
+      "match": "(^!llvm|\\s!llvm)[\\.<]",
+      "captures": {
+        "1": {
+          "name": "variable.mlir"
+        }
+      },
+      "name": "meta.types.llvm.mlir"
+    },
+    "llvmFunc": {
+      "match": "\\bllvm\\.(?=func)",
+      "name": "keyword.function.llvm"
+    },
+    "llvmReturn": {
+      "match": "\\bllvm\\.return\\b",
+      "name": "keyword.return.llvm"
+    },
+    "llvmIntArith": {
+      "match": "\\bllvm\\.(add|sub|mul|udiv|sdiv|urem|srem)\\b",
+      "name": "entity.name.function.mlir.llvmIntArithm"
+    },
+    "llvmFloatArith": {
+      "match": "\\bllvm\\.(fadd|fsub|fmul|fdiv|frem)\\b",
+      "name": "entity.name.function.mlir.llvmFloatArith"
+    },
+    "llvmMemOp": {
+      "match": "\\bllvm\\.(alloca|getelementptr|load|store)\\b",
+      "name": "entity.name.function.mlir.llvmMemOp"
+    },
+    "llvmAggregateOp": {
+      "match": "\\bllvm\\.(extractvalue|insertvalue)\\b",
+      "name": "entity.name.function.mlir.llvmAggregateOp"
+    },
+    "llvmTerminatorOp": {
+      "match": "\\bllvm\\.(br|cond_br|call)\\b",
+      "name": "entity.name.function.mlir.llvmTerminatorOp"
+    },
+    "llvmComparison": {
+      "match": "\\bllvm\\.(eq|ne|slt|sle|sgt|sge|ult|ule|ugt|uge|bitcast|select|icmp)\\b",
+      "name": "entity.name.function.mlir.llvmComparison"
+    },
+    "llvmOps":{
+      "match": "\\bllvm\\.(extractelement|insertelement|shufflevector)\\b",
+      "name":"entity.name.function.mlir.llvmOps"
+    },
+    "llvmMLIR": {
+      "match": "\\b(llvm\\.mlir\\.)((addressof|constant|global|null|undef))",
+      "captures": {
+        "1": {
+          "name": "keyword.other.llvm"
+        },
+        "2": {
+          "name": "entity.name.function.mlir.auxilary"
+        }
+      },
+      "name": "meta.llvm.mlirAuxilary"
+    },
+    "gpuFunc": {
+      "match": "\\bgpu\\.(?=func)",
+      "name": "keyword.function.mlir.gpu"
+    },
+    "gpuReturn": {
+      "match": "\\bgpu\\.return\\b",
+      "name": "keyword.return.mlir.gpu"
+    },
+    "gpuModules": {
+      "match": "\\bgpu\\.(module|container_module|kernel_module)\\b",
+      "name": "keyword.other.mlir.gpu-modules"
+    },
+    "gpuKernel": {
+      "match": "\\bgpu\\.kernel\\b",
+      "name": "keyword.other.mlir.gpu-kernel"
+    },
+    "gpuOpsP": {
+      "match": "(?<=\\W)\"gpu\\.(launch_func|thread_id|block_dim|block_id|grid_dim|all_reduce|yield|shuffle|barrier)\"(?=\\W)",
+      "name": "entity.name.function.mlir.gpuOpsP"
+    },
+    "gpuOps":{
+      "match": "\\bgpu\\.(launch_func|thread_id|block_dim|block_id|grid_dim|all_reduce|yield|shuffle|barrier)\\b",
+      "name": "entity.name.function.mlir.gpuOpsP"
+    },
+    "gpuLaunchAndTerminator": {
+      "match": "\\bgpu\\.(launch|terminator)\\b",
+      "name": "keyword.other.mlir.gpu-launchAndTerminator"
+    },
+    "gpuTestPromoteWorkgroup": {
+      "match": "\\bgpu\\.test_promote_workgroup\\b",
+      "name": "keyword.other.mlir.gpu-testPromoteWorkgroup"
+    },
+    "nvvmID": {
+      "match": "\\bnvvm\\.read\\.ptx\\.sreg\\.(tid|ntid|ctaid|nctaid)\\.(x|y|z)\\b",
+      "name": "entity.name.function.mlir.nvvm-id"
+    },
+    "nvvmLaneId": {
+      "match": "\\bnvvm\\.read\\.ptx\\.sreg\\.laneid\\b",
+      "name": "entity.name.function.mlir.nvvm-laneid"
+    },
+    "nvvmBarrier0": {
+      "match": "\\bnvvm\\.barrier0\\b",
+      "name": "entity.name.function.mlir.nvvm-barrier0"
+    },
+    "nvvmMma": {
+      "match": "\\bnvvm\\.mma\\.sync\\b",
+      "name": "entity.name.function.mlir.nvvm-mma"
+    },
+    "nvvmShflBfly": {
+      "match": "\\bnvvm\\.shfl\\.sync\\.bfly\\b",
+      "name": "entity.name.function.mlir.nvvm-shflbfly"
+    },
+    "nvvmVoteBallot": {
+      "match": "\\bnvvm\\.vote\\.ballot\\.sync\\b",
+      "name": "entity.name.function.mlir.nvvm-voteballot"
+    },
+    "nvvmWarpSize": {
+      "match": "\\bnvvm\\.read\\.ptx\\.sreg\\.warpsize\\b",
+      "name": "entity.name.function.mlir.warpsize"
+    },
+    "tflMath": {
+      "match": "(?<=\\W)\"tfl\\.(abs|add_n|add|cos|div|exp|floor_div|floor_mod|floor|log|log_softmax|mul|pow|round|rsqrt|sin|softmax|sqrt|square|squared_difference|sub|sum|tanh)\"(?=\\W)",
+      "name": "entity.name.function.mlir.tfl_math"
+    },
+    "tflLogic":{
+      "match": "(?<=\\W)\"tfl\\.(equal|greater_equal|greater|less_equal|less|logical_and|logical_not|logical_or|neg|not_equal|select|select_v2|where)\"(?=\\W)",
+      "name": "entity.name.function.mlir.tflLogic"
+    },
+    "tflStats": {
+      "match": "(?<=\\W)\"tfl\\.(arg_max|arg_min|average_pool_2d|max_pool_2d|max_pooling_with_argmax_2d|max_unpooling_2d|maximum|mean|minimum|non_max_suppression_(v4|v5))\"(?=\\W)",
+      "name": "entity.name.function.mlir.tflStats"
+    },
+    "tflConv": {
+      "match": "(?<=\\W)\"tfl\\.(conv_2d|convolution_2d_transpose_bias|depthwise_conv_2d|transpose_conv)\"(?=\\W)",
+      "name": "entity.name.function.mlir.tflConv"
+    },
+    "tflLSTM": {
+      "match": "(?<=\\W)\"tfl\\.(basic_lstm|lstm|unidirectional_sequence_lstm)\"(?=\\W)",
+      "name": "entity.name.function.mlir.tflLSTM"
+    },
+    "tflPseudo": {
+      "match": "(?<=\\W)\"tfl\\.(pseudo_const|pseudo_qconst|pseudo_sparse_const|pseudo_sparse_qconst)\"(?=\\W)",
+      "name": "entity.name.function.mlir.tflPseudo"
+    },
+    "tflTransformations": {
+      "match": "(?<=\\W)\"tfl\\.(batch_to_space_nd|depth_to_space|expand_dims|resize_bilinear|resize_nearest_neighbor|space_to_batch_nd|space_to_depth|sparse_to_dense)\"(?=\\W)",
+      "name": "entity.name.function.mlir.tflReshaping"
+    },
+    "tflRELU": {
+      "match": "(?<=\\W)\"tfl\\.(elu|leaky_relu|prelu|relu_n1_to_1|relu6|relu)\"(?=\\W)",
+      "name": "entity.name.function.mlir.tflRELU"
+    },
+    "tflMatrix": {
+      "match": "(?<=\\W)\"tfl\\.(matrix_diag|matrix_set_diag|mirror_pad|pad|padv2|rank|transpose)\"(?=\\W)",
+      "name": "entity.name.function.mlir.tflMatrix"
+    },
+    "tflOps": {
+      "match": "(?<=\\W)\"tfl\\.(cast|ceil|concatenation|densify|dequantize|fill|gather_nd|gather|logistic|pack|quantize|range|reshape|svdf|shape|slice|split|split_v|squeeze|tile|unique|unpack|while|yield)\"(?=\\W)",
+      "name": "entity.name.function.mlir.tflOps"
+    },
+    "tflLongOps": {
+      "match": "(?<=\\W)\"tfl\\.(embedding_lookup|external_const|fake_quant|fully_connected|hard_swish|NumericVerify|one_hot|segment_sum|strided_slice|topk_v2|zeros_like)\"(<=\\W)",
+      "name": "entity.name.function.mlir.tflLongOps"
+    },
+    "tflNormalization": {
+      "match": "(?<=\\W)\"tfl\\.(l2_normalization|local_response_normalization)\"(?=\\W)",
+      "name": "entity.name.function.mlir.tflNormalization"
+    },
+    "tflReduce": {
+      "match": "(?<=\\W)\"tfl\\.(reduce_any|reduce_max|reduce_min|reduce_prod)\"(?=\\W)",
+      "name": "entity.name.function.mlir.tflReduce"
+    },
+    "tflSequence": {
+      "match": "(?<=\\W)\"tfl\\.(reverse_sequence|reverse_v2|unidirectional_sequence_rnn)\"(?=\\W)",
+      "name": "entity.name.function.mlir.tflSequence"
+    },
+    "vectorOps":{
+      "match": "\\Wvector\\.(broadcast|contract|vectorfma|print|constant_mask|create_mask|shuffle|matrix_multiply|outerproduct|reduction|strided_slice|transpose|type_cast)\\b",
+      "name":"entity.name.function.mlir.vectorOps"
+    },
+    "vectorExtract":{
+      "match" : "\\Wvector\\.(extract|extractelement|extract_slices)\\b",
+      "name": "entity.name.function.mlir.vectorExtract"
+    },
+    "vectorInsert":{
+      "match" : "\\Wvector\\.(insert|insertelement|insert_slices|insert_strided_slice)\\b",
+      "name" : "entity.name.function.mlir.vectorInsert"
+    },
+    "vectorReshape":{
+      "match" : "\\Wvector\\.(reshape|shape_cast)\\b",
+      "name": "entity.name.function.mlir.vectorReshape"
+    },
+    "vectorTransfer":{
+      "match" : "\\Wvector\\.transfer_(read|write)\\b",
+      "name" : "entity.name.function.mlir.vectorTransfer"
+    },
+    "vectorTuple":{
+      "match" : "\\Wvector\\.(tuple|tuple_get)\\b",
+      "name" : "entity.name.function.mlir.vectorTuple"
+    },
+    "loopOps":{
+      "match" : "\\bloop\\.(for|if|parallel|reduce|yield)\\b",
+      "name": "entity.name.function.mlir.loopOps"
+    },
+    "tileFunctions":{
+      "match" : "\\btile\\.(constant|contract|index|reshape)\\b",
+      "name": "entity.name.function.mlir.tileFunctions"
+    },
+    "tileQuotedFunctions":{
+      "match" : "(?<=\\W)\"tile\\.(constant|contract|index|reshape)\"(?=\\W)",
+      "name": "entity.name.function.mlir.tileFunctions"
+    },
+    "tileKeywords": {
+      "match": "\\btile\\.(name)\\b",
+      "name": "keyword.other.mlir.tileKeywords"
+    },
+    "eltwiseFunctions":{
+      "match" : "(?<=\\W)\"eltwise\\.(add|div|sconst|cmp_lt|select|sub|exp|cast|neg|mul|sqrt|ident)\"(?=\\W)",
+      "name": "entity.name.function.mlir.tileFunctions"
+    },
+    "CHECK": {
+      "match": "(\/\/)\\s*(CHECK\\s*:|CHECK-\\w+\\s*:)(.*)$",
+      "captures": {
+        "1": {
+          "name": "comment.line.double-slash.mlir"
+        },
+        "2": {
+          "name": "comment.other.CHECK.mlir"
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "#CHECK-CODE"
+            }
+          ]
+        },
+        "name": "comment.other.CHECK.mlir"
+      }
+    },
+    "CHECK-CODE": {
+      "match": "([^0-9a-zA-Z%\"@]*)?([0-9a-zA-Z\"\\.%_\\-@]*)([^0-9a-zA-Z\"\\.%_\\-].*)?$",
+      "captures": {
+        "1": {
+          "name": "comment.line.double-slash.mlir"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "$self"
+            },
+            {
+              "match": "(\\b|x)(index|i[1-9][0-9]*|f16|bf16|f32|f64|u8|memref|tensor|vector|func)\\b",
+              "captures": {
+                "1": {
+                  "name": "comment.line.double-slash.mlir"
+                },
+                "2": {
+                  "name": "storage.type.mlir"
+                }
+              }
+            },
+            {
+              "match": "\\b([0-9]+)(x.*)?",
+              "captures": {
+                "1": {
+                  "name": "constant.numeric.mlir"
+                },
+                "2": {
+                  "patterns": [
+                    {
+                      "include": "$self"
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "match": "(.*)",
+              "name": "comment.line.double-slash.mlir"
+            }
+          ]
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "#CHECK-CODE"
+            }
+          ]
+        }
+      }
     }
   },
-  "patterns":[
+  "patterns": [
     {
-      "include":"#comment"
-    },
-    {
-      "include":"#string"
-    },
-    {
-      "match":"\\b(func)\\b\\s*(@[\\w_][\\w\\d_.$]*)",
-      "captures":{
-        "1":{
-          "name":"keyword.function.mlir"
+      "match": "\\b(func)\\b\\s*(@[\\w_][\\w\\d_.$]*)",
+      "captures": {
+        "1": {
+          "name": "keyword.function.mlir"
         },
-        "2":{
-          "name":"entity.name.function.mlir"
+        "2": {
+          "name": "entity.name.function.mlir"
         }
       },
-      "name":"support.function.mlir"
+      "name": "support.function.mlir"
     },
     {
-      "match":"\\b(attributes|br|call|constant|loc|return)\\b",
-      "name":"keyword.module.mlir"
+      "match": "\\b(attributes|br|call|constant|loc|return)\\b",
+      "name": "keyword.module.mlir"
     },
     {
-      "include":"#identifier"
+      "include": "#identifier"
     },
     {
-      "include":"#branch_target"
+      "include": "#branch_target"
     },
     {
-      "include":"#attribute"
+      "include": "#attribute"
     },
     {
-      "include":"#types"
+      "include": "#memref-size"
     },
     {
-      "include":"#integer"
+      "include": "#numbers"
+    },
+    {
+      "include": "#affineOps"
+    },
+    {
+      "include": "#affineOpsP"
+    },
+    {
+      "include": "#affineStructures"
+    },
+    {
+      "include": "#else"
+    },
+    {
+      "include": "#CHECK"
+    },
+    {
+      "include": "#llvmType"
+    },
+    {
+      "include": "#llvmFunc"
+    },
+    {
+      "include": "#llvmReturn"
+    },
+    {
+      "include": "#llvmIntArith"
+    },
+    {
+      "include": "#llvmFloatArith"
+    },
+    {
+      "include": "#llvmMemOp"
+    },
+    {
+      "include": "#llvmAggregateOp"
+    },
+    {
+      "include": "#llvmTerminatorOp"
+    },
+    {
+      "include": "#llvmComparison"
+    },
+    {
+      "include": "#llvmMLIR"
+    },
+    {
+      "include": "#llvmOps"
+    },
+    {
+      "include": "#gpuFunc"
+    },
+    {
+      "include": "#gpuReturn"
+    },
+    {
+      "include": "#gpuModules"
+    },
+    {
+      "include": "#gpuKernel"
+    },
+    {
+      "include": "#gpuOpsP"
+    },
+    {
+      "include": "#gpuOps"
+    },
+    {
+      "include": "#gpuLaunchAndTerminator"
+    },
+    {
+      "include": "#gpuTestPromoteWorkgroup"
+    },
+    {
+      "include": "#nvvmID"
+    },
+    {
+      "include": "#nvvmLaneId"
+    },
+    {
+      "include": "#nvvmBarrier0"
+    },
+    {
+      "include": "#nvvmMma"
+    },
+    {
+      "include": "#nvvmShflBfly"
+    },
+    {
+      "include": "#nvvmVoteBallot"
+    },
+    {
+      "include": "#nvvmWarpSize"
+    },
+    {
+      "include": "#tileFunctions"
+    },
+    {
+      "include": "#tileQuotedFunctions"
+    },
+    {
+      "include": "#tileKeywords"
+    },
+    {
+      "include": "#eltwiseFunctions"
+    },
+    {
+      "include": "#tflMath"
+    },
+    {
+      "include": "#tflLogic"
+    },
+    {
+      "include": "#tflStats"
+    },
+    {
+      "include": "#tflConv"
+    },
+    {
+      "include": "#tflLSTM"
+    },
+    {
+      "include": "#tflPseudo"
+    },
+    {
+      "include": "#tflTransformations"
+    },
+    {
+      "include": "#tflRELU"
+    },
+    {
+      "include": "#tflMatrix"
+    },
+    {
+      "include": "#tflOps"
+    },
+    {
+      "include": "#tflLongOps"
+    },
+    {
+      "include": "#tflNormalization"
+    },
+    {
+      "include": "#tflReduce"
+    },
+    {
+      "include": "#tflSequence"
+    },
+    {
+      "include": "#vectorOps"
+    },
+    {
+      "include": "#vectorExtract"
+    },
+    {
+      "include":"#vectorInsert"
+    },
+    {
+      "include":"#vectorReshape"
+    },
+    {
+      "include":"#vectorTransfer"
+    },
+    {
+      "include": "#vectorTuple"
+    },
+    {
+      "include": "#loopOps"
+    },
+    {
+      "include": "#comment"
+    },
+    {
+      "include": "#types"
+    },
+    {
+      "include": "#string"
     }
   ],
-  "name":"MLIR",
-  "scopeName":"source.mlir"
+  "name": "MLIR",
+  "scopeName": "source.mlir"
 }


### PR DESCRIPTION
This updated MLIR grammar file comes from the mlir-visualizer/mlir-vscode repo. It adds support for: Affine Dialect, LLVM IR Dialect, TensorFlow Lite Dialect, Tile Dialect, gpu Dialect, nvvm Dialect, loop Dialect, and the vector Dialect.

The major additions are function name highlighting for the aforementioned dialects, highlighting keywords inside of CHECK comments, and additional data types (such as ui32).

Examples of changes (changes underlined in red summarize other changes in the file):

Affine with original grammar (before):
<img width="1146" alt="oldaffine" src="https://user-images.githubusercontent.com/7445956/81513355-d0194980-92dc-11ea-9736-65fd8c6ce625.png">

Affine with new grammar (after):
<img width="1296" alt="newaffine" src="https://user-images.githubusercontent.com/7445956/81513380-f3dc8f80-92dc-11ea-84b1-b8dccc4f837a.png">

Tile before:
<img width="1151" alt="oldtile" src="https://user-images.githubusercontent.com/7445956/81513470-a876b100-92dd-11ea-8afc-e5f2aee3c412.png">

Tile after:
<img width="1147" alt="newtile" src="https://user-images.githubusercontent.com/7445956/81513461-97c63b00-92dd-11ea-8730-2925406c7ddc.png">


TensorFlow Lite before:
<img width="1362" alt="oldtflite" src="https://user-images.githubusercontent.com/7445956/81513388-035bd880-92dd-11ea-9566-4c1a661ba40c.png">

TensorFlow Lite after:
<img width="1368" alt="newtflite" src="https://user-images.githubusercontent.com/7445956/81513391-09ea5000-92dd-11ea-887f-a366a7d1d5f1.png">

